### PR TITLE
Fix approvals for comparison

### DIFF
--- a/components/Modals/NoteCardModals/DepositModals/EditVault/EditVaultTabContent.tsx
+++ b/components/Modals/NoteCardModals/DepositModals/EditVault/EditVaultTabContent.tsx
@@ -133,7 +133,7 @@ const EditVaultTabContent: React.FC<EditVaultTabContentProps> = ({
       )}
 
       <div className="flex gap-8">
-        {allowance !== undefined && allowance <= toBigNumber(inputValue) && action === "deposit" ? (
+        {allowance !== undefined && allowance < toBigNumber(inputValue, 0) && action === "deposit" ? (
           <div className="w-[100px]">
             <ButtonComponent
               onClick={() =>


### PR DESCRIPTION
inputValue is stored as the uint256 value of input in string format; when converting to compare to allowance, we need to check against it converted with decimals 0 and not the default of 18