### PR TITLE
Update edit vault tab for max withdrawals

### DIFF
--- a/components/Modals/NoteCardModals/DepositModals/EditVault/EditVaultTabContent.tsx
+++ b/components/Modals/NoteCardModals/DepositModals/EditVault/EditVaultTabContent.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import ButtonComponent from "@/components/reusable/ButtonComponent";
 import { DialogClose } from "@/components/ui/dialog";
 import { BigIntInput } from "@/components/reusable/BigIntInput";
 import { formatNumber, fromBigNumber, toBigNumber } from "@/lib/utils";
 import { Address, erc20Abi, maxUint256 } from "viem";
-import { useAccount, useReadContract } from "wagmi";
+import { useAccount, useReadContracts } from "wagmi";
 import { useTransactionStore } from "@/lib/store";
 import {
-  useReadDyadMintedDyad,
-  useReadVaultManagerMinCollaterizationRatio,
+  dyadAbi,
+  dyadAddress,
   vaultManagerAbi,
   vaultManagerAddress,
   wEthVaultAbi,
@@ -38,68 +38,103 @@ const EditVaultTabContent: React.FC<EditVaultTabContentProps> = ({
   const { address } = useAccount();
   const { setTransactionData } = useTransactionStore();
 
-  const { data: mintedDyad } = useReadDyadMintedDyad({
-    args: [BigInt(tokenId)],
-    chainId: defaultChain.id,
+  const { data: contractData } = useReadContracts({
+    allowFailure: false,
+    contracts: [
+      {
+        address: dyadAddress[defaultChain.id],
+        abi: dyadAbi,
+        functionName: "mintedDyad",
+        args: [BigInt(tokenId)],
+        chainId: defaultChain.id,
+      },
+      {
+        address: vaultManagerAddress[defaultChain.id],
+        abi: vaultManagerAbi,
+        functionName: "getTotalValue",
+        args: [BigInt(tokenId)],
+        chainId: defaultChain.id,
+      },
+      {
+        address: vaultAddress,
+        abi: wEthVaultAbi,
+        functionName: "id2asset",
+        args: [BigInt(tokenId)],
+        chainId: defaultChain.id,
+      },
+      {
+        address: vaultAddress,
+        abi: wEthVaultAbi,
+        functionName: "assetPrice",
+        chainId: defaultChain.id,
+      },
+      {
+        address: token,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [address!, vaultManagerAddress[defaultChain.id]],
+        chainId: defaultChain.id,
+      },
+      {
+        address: vaultManagerAddress[defaultChain.id],
+        abi: vaultManagerAbi,
+        functionName: "MIN_COLLAT_RATIO",
+        chainId: defaultChain.id,
+      },
+      {
+        address: token,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [address!],
+      }
+    ],
+    query: {
+      select: (data) => ({
+        mintedDyad: data[0],
+        collateralValue: data[1],
+        totalDeposited: data[2],
+        assetValue: data[3],
+        allowance: data[4],
+        minCollateralizationRatio: data[5],
+        balance: data[6]
+      })
+    }
   });
-
-  const { data: collateralValue } = useReadContract({
-    address: vaultManagerAddress[defaultChain.id],
-    abi: vaultManagerAbi,
-    functionName: "getTotalValue",
-    args: [BigInt(tokenId)],
-    chainId: defaultChain.id,
-  });
-
-  const { data: assetValue } = useReadContract({
-    address: vaultAddress,
-    abi: wEthVaultAbi,
-    functionName: "assetPrice",
-    chainId: defaultChain.id,
-  });
-
-  const { data: allowance } = useReadContract({
-    address: token,
-    abi: erc20Abi,
-    functionName: "allowance",
-    args: [address!, vaultManagerAddress[defaultChain.id]],
-    chainId: defaultChain.id,
-  });
-
-  const { data: minCollateralizationRatio } =
-    useReadVaultManagerMinCollaterizationRatio({ chainId: defaultChain.id });
 
   const newCr =
-    ((fromBigNumber(collateralValue) +
+    ((fromBigNumber(contractData?.collateralValue) +
       (action === "deposit"
-        ? fromBigNumber(inputValue) * fromBigNumber(assetValue, 8)
-        : -fromBigNumber(inputValue) * fromBigNumber(assetValue, 8))) /
-      fromBigNumber(mintedDyad)) *
+        ? fromBigNumber(inputValue) * fromBigNumber(contractData?.assetValue, 8)
+        : -fromBigNumber(inputValue) * fromBigNumber(contractData?.assetValue, 8))) /
+      fromBigNumber(contractData?.mintedDyad)) *
     100;
 
-  const { data: balance } = useReadContract({
-    address: token,
-    abi: erc20Abi,
-    functionName: "balanceOf",
-    args: [address!],
-  });
+  const theoreticalMaxWithdraw = useMemo(() => {
+    const totalAssetDeposited = fromBigNumber(contractData?.totalDeposited);
+    const price = fromBigNumber(contractData?.assetValue, 8)
+
+    const totalCollateral = fromBigNumber(contractData?.collateralValue)
+    const totalDyad = fromBigNumber(contractData?.mintedDyad)
+    const minCollateralRatio = fromBigNumber(contractData?.minCollateralizationRatio);
+
+    const maxWithdraw = ((totalCollateral - (totalDyad * minCollateralRatio)) / price) - 0.000001;
+
+    if (maxWithdraw < totalAssetDeposited) {
+      return toBigNumber(maxWithdraw);
+    }
+    return contractData?.totalDeposited;
+  }, [contractData]);
 
   const maxHandler = () => {
     if (action === "deposit") {
-      setInputValue(balance?.toString() || "0");
+      setInputValue(contractData?.balance?.toString() || "0");
     }
     if (action === "withdraw") {
-      const theoreticalMax = toBigNumber(
-        (fromBigNumber(collateralValue) -
-          fromBigNumber(mintedDyad) *
-            fromBigNumber(minCollateralizationRatio)) /
-          fromBigNumber(assetValue, 8)
-      );
-      setInputValue((theoreticalMax - toBigNumber(0.000001)).toString());
+      setInputValue(theoreticalMaxWithdraw?.toString() || "0");
     }
 
     if (action === "redeem") {
-      setInputValue((mintedDyad || 0n).toString());
+      setInputValue((contractData?.mintedDyad || 0n).toString());
     }
   };
 
@@ -119,7 +154,7 @@ const EditVaultTabContent: React.FC<EditVaultTabContentProps> = ({
           </ButtonComponent>
         </div>
       </div>
-      {mintedDyad !== 0n && !!mintedDyad && action !== "redeem" && (
+      {contractData?.mintedDyad !== 0n && !!contractData?.mintedDyad && action !== "redeem" && (
         <div className="flex flex-col w-full justify-between font-semibold text-sm">
           <div className="flex text-[#A1A1AA]">
             <div className="mr-[5px]">Current collateralization ratio:</div>
@@ -133,7 +168,7 @@ const EditVaultTabContent: React.FC<EditVaultTabContentProps> = ({
       )}
 
       <div className="flex gap-8">
-        {allowance !== undefined && allowance < toBigNumber(inputValue, 0) && action === "deposit" ? (
+        {contractData?.allowance !== undefined && contractData?.allowance < toBigNumber(inputValue, 0) && action === "deposit" ? (
           <div className="w-[100px]">
             <ButtonComponent
               onClick={() =>

--- a/components/NoteCard/Children/Mint.tsx
+++ b/components/NoteCard/Children/Mint.tsx
@@ -7,7 +7,7 @@ import { useTransactionStore } from "@/lib/store";
 import {
   useReadDyadMintedDyad,
   useReadVaultManagerGetTotalValue,
-  useReadVaultManagerMinCollaterizationRatio,
+  useReadVaultManagerMinCollatRatio,
   vaultManagerAbi,
   vaultManagerAddress,
 } from "@/generated";
@@ -38,7 +38,7 @@ const Mint: React.FC<MintProps> = ({ dyadMinted, currentCr, tokenId }) => {
   });
 
   const { data: minCollateralizationRatio } =
-    useReadVaultManagerMinCollaterizationRatio({ chainId: defaultChain.id });
+    useReadVaultManagerMinCollatRatio({ chainId: defaultChain.id });
 
   const newCr =
     (mintedDyad || 0n) +

--- a/components/NoteCard/NoteCard.tsx
+++ b/components/NoteCard/NoteCard.tsx
@@ -7,7 +7,7 @@ import {
   useReadDyadMintedDyad,
   useReadVaultManagerCollatRatio,
   useReadVaultManagerGetTotalValue,
-  useReadVaultManagerMinCollaterizationRatio,
+  useReadVaultManagerMinCollatRatio,
   vaultManagerAbi,
   vaultManagerAddress,
   wEthVaultAbi,
@@ -70,7 +70,7 @@ function NoteCard({tokenId}: {tokenId: string}) {
     .filter((data) => !!data.value);
 
   const {data: minCollateralizationRatio} =
-    useReadVaultManagerMinCollaterizationRatio({chainId: defaultChain.id});
+    useReadVaultManagerMinCollatRatio({chainId: defaultChain.id});
 
   const totalCollateral = `$${formatNumber(fromBigNumber(collateralValue))}`;
   const collateralizationRatio =

--- a/lib/abi/VaultManager.ts
+++ b/lib/abi/VaultManager.ts
@@ -125,7 +125,7 @@ export const vaultManagerAbi = [
   },
   {
     inputs: [],
-    name: "MIN_COLLATERIZATION_RATIO",
+    name: "MIN_COLLAT_RATIO",
     outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
     stateMutability: "view",
     type: "function",


### PR DESCRIPTION
- Update to use multicall so all contract calls are made with a single RPC call
- Update vault manager ABI with correct MIN_COLLAT_RATIO function name for V2
- Update max withdrawal button to factor in TOTAL collateral across multiple vaults when withdrawing max:
 - If removing all of the collateral from current vault would retain a CR > minimum, use the entire deposited amount
 - If removing all of the collateral from current vault would result in a CR < minimum, compute the maximum to withdraw minus a small buffer amount