### PR TITLE
add merkl claim directly if user has wallet connected

### DIFF
--- a/components/earn-kerosene.tsx
+++ b/components/earn-kerosene.tsx
@@ -2,10 +2,64 @@ import ButtonComponent from "@/components/reusable/ButtonComponent";
 import NoteCardsContainer from "../components/reusable/NoteCardsContainer";
 import { ClaimModalContent } from "./claim-modal-content";
 import { useMerklCampaign } from "@/hooks/useMerklCampaign";
+import { useAccount } from "wagmi";
+import { useMerklRewards } from "@/hooks/useMerklRewards";
+import { formatEther } from "viem";
+import {
+  keroseneAddress,
+  useSimulateDistributorClaim,
+  useWriteDistributorClaim,
+} from "@/generated";
+import { defaultChain } from "@/lib/config";
+import useKerosenePrice from "@/hooks/useKerosenePrice";
+import { useMemo } from "react";
 
 export function EarnKeroseneContent() {
+  const { address } = useAccount();
 
   const { currentCampaign: merklData } = useMerklCampaign();
+  const { merklRewards, error, loading, refetch } = useMerklRewards({
+    address,
+  });
+
+  const { data: claimMerklRewardsConfig } = useSimulateDistributorClaim({
+    args: [
+      [address!],
+      [keroseneAddress[defaultChain.id]],
+      [merklRewards?.accumulated || 0n],
+      [merklRewards?.proof || []],
+    ],
+    query: {
+      enabled:
+        address !== undefined &&
+        merklRewards !== undefined &&
+        merklRewards.accumulated > 0n,
+    },
+  });
+
+  const { kerosenePrice } = useKerosenePrice();
+
+  const { totalUsd, claimableUsd } = useMemo(() => {
+    if (merklRewards === undefined || kerosenePrice === undefined) {
+      return { totalUsd: 0, claimableUsd: 0 };
+    }
+
+    let totalUsd =
+      Number(formatEther(merklRewards.accumulated || 0n)) * kerosenePrice;
+    totalUsd = Number(totalUsd.toFixed(2));
+
+    let claimableUsd =
+      Number(formatEther(merklRewards.unclaimed || 0n)) * kerosenePrice;
+    claimableUsd = Number(claimableUsd.toFixed(2));
+
+    return {
+      totalUsd: totalUsd.toLocaleString(),
+      claimableUsd: claimableUsd.toLocaleString(),
+    };
+  }, [merklRewards, kerosenePrice]);
+
+  const { writeContract: claimMerklRewards, error: claimError } =
+    useWriteDistributorClaim();
 
   return (
     <div>
@@ -77,21 +131,68 @@ export function EarnKeroseneContent() {
           <div className="text-sm font-semibold text-[#A1A1AA]">
             <div className="flex w-full flex justify-between items-center">
               <div className="text-2xl text-[#FAFAFA]  ">
-                That's it. No staking necessary.
+                Step 4: Claim Rewards
               </div>
             </div>
-            <div className="flex justify-between mt-[32px] w-full">
-              <div className="w-full">
-                <ButtonComponent
-                  onClick={() =>
-                    window.open(
-                      "https://merkl.angle.money/ethereum/pool/0x8B238f615c1f312D22A65762bCf601a37f1EeEC7"
-                    )
-                  }
-                >
-                  Check your earnings on Merkl
-                </ButtonComponent>
-              </div>
+
+            <div className="flex flex-col gap-4 justify-between mt-[32px] w-full">
+              {address === undefined ? (
+                <>
+                  <p>Connect Wallet to see rewards or</p>
+                  <ButtonComponent
+                    onClick={() =>
+                      window.open(
+                        "https://merkl.angle.money/user/"
+                      )
+                    }
+                  >
+                    Check your earnings on Merkl
+                  </ButtonComponent>
+                </>
+              ) : (
+                <>
+                  <div className="w-full grid grid-cols-3">
+                    {loading ? (
+                      <p>Loading...</p>
+                    ) : error ? (
+                      <p className="grid-span-3">{error}</p>
+                    ) : (
+                      <>
+                        <p>Your total earnings</p>
+                        <p>
+                          {Number(
+                            formatEther(merklRewards?.accumulated || 0n)
+                          ).toLocaleString()}{" "}
+                          KEROSENE
+                        </p>
+                        <p>{totalUsd && `$${totalUsd}`}</p>
+                        <p>Total claimable</p>
+                        <p>
+                          {Number(
+                            formatEther(merklRewards?.unclaimed || 0n)
+                          ).toLocaleString()}{" "}
+                          KEROSENE
+                        </p>
+                        <p>{claimableUsd && `$${claimableUsd}`}</p>
+                      </>
+                    )}
+                  </div>
+                  {merklRewards &&
+                    merklRewards.unclaimed > 0n &&
+                    claimMerklRewardsConfig != undefined &&
+                    claimError === null && (
+                      <div className="w-full">
+                        <ButtonComponent
+                          onClick={() => {
+                            claimMerklRewards(claimMerklRewardsConfig.request);
+                          }}
+                        >
+                          Claim
+                        </ButtonComponent>
+                      </div>
+                    )}
+                </>
+              )}
             </div>
           </div>
         </NoteCardsContainer>

--- a/components/earn-kerosene.tsx
+++ b/components/earn-kerosene.tsx
@@ -74,7 +74,7 @@ export function EarnKeroseneContent() {
     if (!!address && claimTransaction?.status === "success") {
       refetch(address);
     }
-  });
+  }, [address, claimTransaction, refetch]);
 
   return (
     <div>

--- a/hooks/useMerklRewards.ts
+++ b/hooks/useMerklRewards.ts
@@ -17,13 +17,14 @@ export const useMerklRewards = ({ address }: { address: `0x${string}` | undefine
     const [error, setError] = useState<string | undefined>(undefined);
 
     const getMerklRewards = useCallback(async (address: `0x${string}`) => {
-
+        setLoading(true);
         try {
             const res = await fetch(`https://api.merkl.xyz/v3/rewards?user=${address}&chainIds=1`);
             const data = await res.json()
 
             const rewards = data["1"].tokenData[keroseneAddress[defaultChain.id]];
 
+            console.log(rewards)
             if (rewards) {
                 setMerklRewards({
                     accumulated: BigInt(rewards.accumulated),
@@ -36,7 +37,7 @@ export const useMerklRewards = ({ address }: { address: `0x${string}` | undefine
             setError("Error fetching rewards. Please try again later.")
         }
         setLoading(false)
-    }, [setMerklRewards])
+    }, [setLoading, setError, setMerklRewards])
 
     useEffect(() => {
         if (address) {

--- a/hooks/useMerklRewards.ts
+++ b/hooks/useMerklRewards.ts
@@ -1,0 +1,53 @@
+import { keroseneAddress } from "@/generated";
+import { defaultChain } from "@/lib/config";
+import { error } from "console";
+import { useCallback, useEffect, useState } from "react"
+
+type MerklRewards = {
+    accumulated: bigint,
+    decimals: number,
+    proof: `0x${string}`[],
+    unclaimed: bigint,
+}
+
+export const useMerklRewards = ({ address }: { address: `0x${string}` | undefined }) => {
+
+    const [loading, setLoading] = useState<boolean>(true);
+    const [merklRewards, setMerklRewards] = useState<MerklRewards | undefined>(undefined);
+    const [error, setError] = useState<string | undefined>(undefined);
+
+    const getMerklRewards = useCallback(async (address: `0x${string}`) => {
+
+        try {
+            const res = await fetch(`https://api.merkl.xyz/v3/rewards?user=${address}&chainIds=1`);
+            const data = await res.json()
+
+            const rewards = data["1"].tokenData[keroseneAddress[defaultChain.id]];
+
+            if (rewards) {
+                setMerklRewards({
+                    accumulated: BigInt(rewards.accumulated),
+                    decimals: rewards.decimals,
+                    proof: rewards.proof,
+                    unclaimed: BigInt(rewards.unclaimed),
+                });
+            }
+        } catch (e) {
+            setError("Error fetching rewards. Please try again later.")
+        }
+        setLoading(false)
+    }, [setMerklRewards])
+
+    useEffect(() => {
+        if (address) {
+            getMerklRewards(address);
+        }
+    }, [address, getMerklRewards])
+
+    return {
+        merklRewards,
+        loading,
+        error,
+        refetch: getMerklRewards
+    };
+}

--- a/lib/abi/AngleDistributor.ts
+++ b/lib/abi/AngleDistributor.ts
@@ -1,0 +1,796 @@
+export const angleDistributorAbi = [
+    {
+        "inputs": [],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidDispute",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidLengths",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidProof",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidUninitializedRoot",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NoDispute",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NotGovernor",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NotTrusted",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NotWhitelisted",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnresolvedDispute",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZeroAddress",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "previousAdmin",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "newAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "AdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "beacon",
+                "type": "address"
+            }
+        ],
+        "name": "BeaconUpgraded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Claimed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "_disputeAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "DisputeAmountUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint48",
+                "name": "_disputePeriod",
+                "type": "uint48"
+            }
+        ],
+        "name": "DisputePeriodUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "valid",
+                "type": "bool"
+            }
+        ],
+        "name": "DisputeResolved",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "_disputeToken",
+                "type": "address"
+            }
+        ],
+        "name": "DisputeTokenUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "reason",
+                "type": "string"
+            }
+        ],
+        "name": "Disputed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "version",
+                "type": "uint8"
+            }
+        ],
+        "name": "Initialized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "isEnabled",
+                "type": "bool"
+            }
+        ],
+        "name": "OperatorClaimingToggled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "isWhitelisted",
+                "type": "bool"
+            }
+        ],
+        "name": "OperatorToggled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Recovered",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [],
+        "name": "Revoked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "merkleRoot",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "ipfsHash",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint48",
+                "name": "endOfDisputePeriod",
+                "type": "uint48"
+            }
+        ],
+        "name": "TreeUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "eoa",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "trust",
+                "type": "bool"
+            }
+        ],
+        "name": "TrustedToggled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            }
+        ],
+        "name": "Upgraded",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "canUpdateMerkleRoot",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "users",
+                "type": "address[]"
+            },
+            {
+                "internalType": "address[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes32[][]",
+                "name": "proofs",
+                "type": "bytes32[][]"
+            }
+        ],
+        "name": "claim",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "claimed",
+        "outputs": [
+            {
+                "internalType": "uint208",
+                "name": "amount",
+                "type": "uint208"
+            },
+            {
+                "internalType": "uint48",
+                "name": "timestamp",
+                "type": "uint48"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "merkleRoot",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "core",
+        "outputs": [
+            {
+                "internalType": "contract ICore",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "disputeAmount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "disputePeriod",
+        "outputs": [
+            {
+                "internalType": "uint48",
+                "name": "",
+                "type": "uint48"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "disputeToken",
+        "outputs": [
+            {
+                "internalType": "contract IERC20",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "reason",
+                "type": "string"
+            }
+        ],
+        "name": "disputeTree",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "disputer",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "endOfDisputePeriod",
+        "outputs": [
+            {
+                "internalType": "uint48",
+                "name": "",
+                "type": "uint48"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getMerkleRoot",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract ICore",
+                "name": "_core",
+                "type": "address"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "lastTree",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "merkleRoot",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "ipfsHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "onlyOperatorCanClaim",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "operators",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "proxiableUUID",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "tokenAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amountToRecover",
+                "type": "uint256"
+            }
+        ],
+        "name": "recoverERC20",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bool",
+                "name": "valid",
+                "type": "bool"
+            }
+        ],
+        "name": "resolveDispute",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "revokeTree",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_disputeAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "setDisputeAmount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint48",
+                "name": "_disputePeriod",
+                "type": "uint48"
+            }
+        ],
+        "name": "setDisputePeriod",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IERC20",
+                "name": "_disputeToken",
+                "type": "address"
+            }
+        ],
+        "name": "setDisputeToken",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            }
+        ],
+        "name": "toggleOnlyOperatorCanClaim",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            }
+        ],
+        "name": "toggleOperator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "eoa",
+                "type": "address"
+            }
+        ],
+        "name": "toggleTrusted",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "tree",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "merkleRoot",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "ipfsHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "merkleRoot",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "ipfsHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct MerkleTree",
+                "name": "_tree",
+                "type": "tuple"
+            }
+        ],
+        "name": "updateTree",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            }
+        ],
+        "name": "upgradeTo",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "upgradeToAndCall",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    }
+]

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -9,10 +9,18 @@ import { vaultAbi } from "@/lib/abi/Vault";
 import { paymentsAbi } from "@/lib/abi/Payments";
 import { merkleClaimAbi } from "@/lib/abi/MerkleClaim";
 import { erc20Abi } from "viem";
+import { angleDistributorAbi } from "./lib/abi/AngleDistributor";
 
 export default defineConfig({
   out: "generated.ts",
   contracts: [
+    {
+      name: "Distributor",
+      address: {
+        [mainnet.id]: "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae",
+      },
+      abi: angleDistributorAbi,
+    },
     {
       name: "MerkleClaimERC20",
       address: {


### PR DESCRIPTION
Adds merkl rewards directly to the "Earn Kerosene" tab, with a claim button if user is eligible to claim.

Directs user to connect wallet or visit Merkl if they do not have their wallet connected.

<img width="737" alt="image" src="https://github.com/DyadStablecoin/frontend/assets/137969418/a4b84110-80f1-475e-8578-a5769972c400">
<img width="736" alt="image" src="https://github.com/DyadStablecoin/frontend/assets/137969418/99925d53-c694-4cba-9ffe-8d89f087477c">

