### PR TITLE
Refactor mint component

### DIFF
--- a/components/NoteCard/NoteCard.tsx
+++ b/components/NoteCard/NoteCard.tsx
@@ -192,7 +192,6 @@ function NoteCard({ tokenId }: { tokenId: string }) {
       tabKey: "Mint DYAD",
       content: (
         <Mint
-          dyadMinted={totalDyad}
           currentCr={collatRatio}
           tokenId={tokenId}
         />


### PR DESCRIPTION
- Update to use multicall to load all necessary data with minimal RPC calls
- Improve collateral calculation to respect kerosene dollar rule - `totalCollateral` reflects at most 2x exogenous collateral if kero collateral exceeds exogenous
- Max mint will calculate amount to mint to 151% CR
- Improve display of values at bottom bar, include Kero collateral in display